### PR TITLE
include manpages during install

### DIFF
--- a/rofi-git/PKGBUILD
+++ b/rofi-git/PKGBUILD
@@ -33,5 +33,5 @@ build() {
 
 package() {
   cd "$srcdir/$_gitname"
-  make install DESTDIR="$pkgdir"
+  make install install-man DESTDIR="$pkgdir"
 }


### PR DESCRIPTION
running `rofi -h` complains about missing rofi.1 man page which is only installed when you call the `make install-man` target.
